### PR TITLE
Fix citizen follow through vehicle rides

### DIFF
--- a/DataModels/CameraDataModel.cs
+++ b/DataModels/CameraDataModel.cs
@@ -28,14 +28,28 @@ namespace FirstPersonCameraContinued.DataModels
             set;
         }
 
+        public FollowTargetState<Entity> FollowTarget
+        {
+            get;
+        } = new FollowTargetState<Entity>(Entity.Null);
+
         /// <summary>
-        /// The entity we may be following
+        /// The entity the user intentionally selected to follow.
         /// </summary>
         public Entity FollowEntity
         {
-            get;
-            set;
-        } = Entity.Null;
+            get => FollowTarget.SelectedSubject;
+            set => FollowTarget.SelectSubject(value);
+        }
+
+        /// <summary>
+        /// The entity currently used for camera position and rotation.
+        /// </summary>
+        public Entity AttachmentTarget
+        {
+            get => FollowTarget.AttachmentTarget;
+            set => FollowTarget.ResolveAttachmentTarget(value);
+        }
 
         /// <summary>
         /// Is the player sprinting?

--- a/DataModels/FollowTargetState.cs
+++ b/DataModels/FollowTargetState.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace FirstPersonCameraContinued.DataModels
+{
+    public class FollowTargetState<TEntity>
+    {
+        private readonly TEntity _nullEntity;
+        private readonly IEqualityComparer<TEntity> _comparer;
+
+        public FollowTargetState(TEntity nullEntity)
+            : this(nullEntity, EqualityComparer<TEntity>.Default)
+        {
+        }
+
+        public FollowTargetState(TEntity nullEntity, IEqualityComparer<TEntity> comparer)
+        {
+            _nullEntity = nullEntity;
+            _comparer = comparer;
+            SelectedSubject = nullEntity;
+            AttachmentTarget = nullEntity;
+        }
+
+        public TEntity SelectedSubject { get; private set; }
+
+        public TEntity AttachmentTarget { get; private set; }
+
+        public bool HasSubject => !_comparer.Equals(SelectedSubject, _nullEntity);
+
+        public void SelectSubject(TEntity subject)
+        {
+            SelectedSubject = subject;
+            AttachmentTarget = subject;
+        }
+
+        public void ResolveAttachmentTarget(TEntity target)
+        {
+            AttachmentTarget = HasSubject ? target : _nullEntity;
+        }
+    }
+}

--- a/EntityFollower.cs
+++ b/EntityFollower.cs
@@ -28,75 +28,65 @@ namespace FirstPersonCameraContinued
         }
 
         /// <summary>
-        /// Filter the current entity
+        /// Resolve the current camera attachment target without changing the selected follow subject.
         /// </summary>
-        private void Filter( )
+        public Entity ResolveAttachmentTarget()
         {
-            // Check and update entity based on TargetElement buffer
-            if ( _entityManager.TryGetBuffer<TargetElement>( _model.FollowEntity, true, out var buffer ) && buffer.Length > 0 )
+            var target = _model.FollowEntity;
+
+            if (target == Entity.Null || !_entityManager.Exists(target))
             {
-                _model.FollowEntity = buffer[0].m_Entity;
+                _model.AttachmentTarget = Entity.Null;
+                return Entity.Null;
+            }
+
+            // Check and update entity based on TargetElement buffer
+            if (_entityManager.TryGetBuffer<TargetElement>(target, true, out var buffer) && buffer.Length > 0)
+            {
+                target = buffer[0].m_Entity;
             }
 
             // Check and update entity based on CurrentTransport component
-            if ( TryGetComponent<CurrentTransport>( out var transport ) )
+            if ( TryGetComponent(target, out CurrentTransport transport) )
             {
-                _model.FollowEntity = transport.m_CurrentTransport;
+                target = transport.m_CurrentTransport;
             }
 
             // Further processing if entity has Unspawned component
-            if ( HasComponent<Game.Objects.Unspawned>( ) )
+            if ( HasComponent<Game.Objects.Unspawned>(target) )
             {
                 // Check and update entity based on CurrentVehicle component
-                if ( TryGetComponent<CurrentVehicle>( out var vehicle ) )
+                if ( TryGetComponent(target, out CurrentVehicle vehicle) )
                 {
-                    _model.FollowEntity = vehicle.m_Vehicle;
+                    target = vehicle.m_Vehicle;
                 }
                 // Check and update entity based on Resident component and its CurrentBuilding
-                else if ( TryGetComponent<Game.Creatures.Resident>( out var residentComponent ) &&
+                else if ( TryGetComponent(target, out Game.Creatures.Resident residentComponent) &&
                          TryGetComponent<CurrentBuilding>( residentComponent.m_Citizen, out var houseResident ) )
                 {
-                    _model.FollowEntity = houseResident.m_CurrentBuilding;
+                    target = houseResident.m_CurrentBuilding;
                 }
                 // Check and update entity based on Pet component and its CurrentBuilding
-                else if ( TryGetComponent<Game.Creatures.Pet>( out var petComponent ) &&
+                else if ( TryGetComponent(target, out Game.Creatures.Pet petComponent) &&
                          TryGetComponent<CurrentBuilding>( petComponent.m_HouseholdPet, out var housePet ) )
                 {
-                    _model.FollowEntity = housePet.m_CurrentBuilding;
+                    target = housePet.m_CurrentBuilding;
                 }
             }
 
-
-            // switch back to following cim entity after exiting vehicle
-            if (_entityManager.TryGetComponent<Game.Creatures.Resident>(_model.LastFollowEntity, out var lastEntityResident) && lastEntityResident.m_Flags.HasFlag(ResidentFlags.Disembarking))
+            if (target != Entity.Null && !_entityManager.Exists(target))
             {
-                //Mod.log.Info("Cim Disembarking " + _model.FollowEntity);
-                _model.FollowEntity = _model.LastFollowEntity;
+                target = Entity.Null;
             }
 
+            _model.AttachmentTarget = target;
+            return target;
         }
 
-        /// <summary>
-        /// Shortcut for checking if a component exists
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        private bool HasComponent<T>( )
+        private bool HasComponent<T>( Entity entity )
             where T : unmanaged, IComponentData
         {
-            return _entityManager.HasComponent<T>( _model.FollowEntity );
-        }
-
-        /// <summary>
-        /// Shortcut for getting a component
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="component"></param>
-        /// <returns></returns>
-        private bool TryGetComponent<T>( out T component )
-            where T : unmanaged, IComponentData
-        {
-            return _entityManager.TryGetComponent( _model.FollowEntity, out component );
+            return entity != Entity.Null && _entityManager.Exists(entity) && _entityManager.HasComponent<T>( entity );
         }
 
         /// <summary>
@@ -109,7 +99,8 @@ namespace FirstPersonCameraContinued
         private bool TryGetComponent<T>( Entity entity, out T component )
             where T : unmanaged, IComponentData
         {
-            return _entityManager.TryGetComponent( entity, out component );
+            component = default;
+            return entity != Entity.Null && _entityManager.Exists(entity) && _entityManager.TryGetComponent( entity, out component );
         }
 
         /// <summary>
@@ -198,45 +189,51 @@ namespace FirstPersonCameraContinued
             rotation = default;
             isTrain = false;
 
-            Filter();
-            if (_entityManager.TryGetComponent<Game.Vehicles.TrainNavigation>(_model.FollowEntity, out var trainNavigationComponent))
+            var target = ResolveAttachmentTarget();
+            if (target == Entity.Null)
+                return false;
+
+            if (_entityManager.TryGetComponent<Game.Vehicles.TrainNavigation>(target, out var trainNavigationComponent))
             {
-                if (_entityManager.TryGetComponent<Game.Rendering.InterpolatedTransform>(_model.FollowEntity, out var interpolatedTransformComponent))
+                if (_entityManager.TryGetComponent<Game.Rendering.InterpolatedTransform>(target, out var interpolatedTransformComponent))
                 {
                     position = interpolatedTransformComponent.m_Position;
                     rotation = interpolatedTransformComponent.m_Rotation;
                     isTrain = true;
+                    return true;
                 }
             }
             else
             {
-                if (_entityManager.TryGetBuffer<Game.Objects.TransformFrame>(_model.FollowEntity, true, out var buffer1))
+                if (_entityManager.TryGetBuffer<Game.Objects.TransformFrame>(target, true, out var buffer1))
                 {
-                    var interpolatedPosition = GetInterpolatedPosition(_model.FollowEntity, buffer1, out bounds);
+                    var interpolatedPosition = GetInterpolatedPosition(target, buffer1, out bounds);
                     position = interpolatedPosition.m_Position;
                     rotation = interpolatedPosition.m_Rotation;
+                    return true;
                 }
                 else
                 {
-                    if (_entityManager.TryGetComponent<Game.Objects.Relative>(_model.FollowEntity, out var component1))
+                    if (_entityManager.TryGetComponent<Game.Objects.Relative>(target, out var component1))
                     {
-                        var relativePosition = GetRelativePosition(_model.FollowEntity, component1, out bounds);
+                        var relativePosition = GetRelativePosition(target, component1, out bounds);
                         position = relativePosition.m_Position;
                         rotation = relativePosition.m_Rotation;
+                        return true;
                     }
                     else
                     {
-                        if (_entityManager.TryGetComponent<Game.Objects.Transform>(_model.FollowEntity, out var component2))
+                        if (_entityManager.TryGetComponent<Game.Objects.Transform>(target, out var component2))
                         {
-                            var objectPosition = GetObjectPosition(_model.FollowEntity, component2, out bounds);
+                            var objectPosition = GetObjectPosition(target, component2, out bounds);
                             position = objectPosition.m_Position;
                             rotation = objectPosition.m_Rotation;
+                            return true;
                         }
                     }
                 }
-                isTrain = false;
             }
-            return true;
+            return false;
         }
 
         /// <summary>
@@ -248,34 +245,39 @@ namespace FirstPersonCameraContinued
         {
             position = default;
 
-            Filter( );
+            var target = ResolveAttachmentTarget();
+            if (target == Entity.Null)
+                return false;
 
             //if ( _entityManager.TryGetComponent<InterpolatedTransform>( _model.FollowEntity, out var interpolatedTransform ) )
             //{
             //    position = interpolatedTransform.m_Position;
             //}
-            if ( _entityManager.TryGetBuffer<Game.Objects.TransformFrame>( _model.FollowEntity, true, out var buffer1 ) )
+            if ( _entityManager.TryGetBuffer<Game.Objects.TransformFrame>( target, true, out var buffer1 ) )
             {
-                var interpolatedPosition = GetInterpolatedPosition( _model.FollowEntity, buffer1, out _ );
+                var interpolatedPosition = GetInterpolatedPosition( target, buffer1, out _ );
                 position = interpolatedPosition.m_Position;
+                return true;
             }
             else
             {
-                if ( _entityManager.TryGetComponent<Game.Objects.Relative>( _model.FollowEntity, out var component1 ) )
+                if ( _entityManager.TryGetComponent<Game.Objects.Relative>( target, out var component1 ) )
                 {
-                    var relativePosition = GetRelativePosition( _model.FollowEntity, component1, out _ );
+                    var relativePosition = GetRelativePosition( target, component1, out _ );
                     position = relativePosition.m_Position;
+                    return true;
                 }
                 else
                 {
-                    if ( _entityManager.TryGetComponent<Game.Objects.Transform>( _model.FollowEntity, out var component2 ) )
+                    if ( _entityManager.TryGetComponent<Game.Objects.Transform>( target, out var component2 ) )
                     {
-                        var objectPosition = GetObjectPosition( _model.FollowEntity, component2, out _ );
+                        var objectPosition = GetObjectPosition( target, component2, out _ );
                         position = objectPosition.m_Position;
+                        return true;
                     }
                 }
             }
-            return true;
+            return false;
         }
 
         /// <summary>
@@ -288,18 +290,21 @@ namespace FirstPersonCameraContinued
         {
             rotation = default;
 
-            var workingEntity = entity != default ? entity : _model.FollowEntity;
+            var workingEntity = entity != default ? entity : ResolveAttachmentTarget();
 
-            Filter( );
+            if (workingEntity == Entity.Null)
+                return false;
 
-            if ( _entityManager.TryGetComponent<InterpolatedTransform>( _model.FollowEntity, out var interpolatedTransform ) )
+            if ( _entityManager.TryGetComponent<InterpolatedTransform>( workingEntity, out var interpolatedTransform ) )
             {
                 rotation = interpolatedTransform.m_Rotation;
+                return true;
             }
             else if ( _entityManager.TryGetBuffer<Game.Objects.TransformFrame>( workingEntity, true, out var buffer1 ) )
             {
                 var interpolatedPosition = GetInterpolatedPosition( workingEntity, buffer1, out _ );
                 rotation = interpolatedPosition.m_Rotation;
+                return true;
             }
             else
             {
@@ -307,6 +312,7 @@ namespace FirstPersonCameraContinued
                 {
                     var relativePosition = GetRelativePosition( workingEntity, component1, out _ );
                     rotation = relativePosition.m_Rotation;
+                    return true;
                 }
                 else
                 {
@@ -314,10 +320,11 @@ namespace FirstPersonCameraContinued
                     {
                         var objectPosition = GetObjectPosition( workingEntity, component2, out _ );
                         rotation = objectPosition.m_Rotation;
+                        return true;
                     }
                 }
             }
-            return true;
+            return false;
         }
     }
 }

--- a/FirstPersonCameraContinued.csproj
+++ b/FirstPersonCameraContinued.csproj
@@ -87,6 +87,7 @@
 			<Private>false</Private>
 		</Reference>
 		<Reference Include="Newtonsoft.Json">
+		  <HintPath>$(ManagedPath)\Newtonsoft.Json.dll</HintPath>
 		  <Private>False</Private>
 		</Reference>
 		<Reference Include="Unity.InputSystem">
@@ -149,6 +150,10 @@
 
 	<ItemGroup>
 	  <PackageReference Include="Lib.Harmony" Version="2.2.2" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <Compile Remove="Tests\**\*.cs" />
 	</ItemGroup>
 	
 <Target Name="BuildUI" AfterTargets="AfterBuild">

--- a/MonoBehaviours/FirstPersonCameraController.cs
+++ b/MonoBehaviours/FirstPersonCameraController.cs
@@ -44,6 +44,11 @@ namespace FirstPersonCameraContinued.MonoBehaviours
             return _model.FollowEntity;
         }
 
+        public Entity GetAttachmentTarget()
+        {
+            return _model.AttachmentTarget;
+        }
+
         public quaternion GetViewRotation()
         {
             return _model.Rotation;

--- a/Systems/FirstPersonCameraActivatedUISystem.cs
+++ b/Systems/FirstPersonCameraActivatedUISystem.cs
@@ -143,7 +143,7 @@ namespace FirstPersonCameraContinued.Systems
                 {
                     return;
                 }
-                Entity currentEntity = CameraController.GetFollowEntity();
+                Entity currentEntity = CameraController.GetAttachmentTarget();
 
                 if (currentEntity != Entity.Null)
                 {
@@ -749,7 +749,7 @@ namespace FirstPersonCameraContinued.Systems
                 foreach (var station in stations)
                 {
                     string baseName = GetStreetBaseName(station.streetName);
-                    nameCount[baseName] = nameCount.GetValueOrDefault(baseName, 0) + 1;
+                    nameCount[baseName] = GetDictionaryValueOrDefault(nameCount, baseName) + 1;
                 }
 
                 if (goingInbound)
@@ -914,12 +914,17 @@ namespace FirstPersonCameraContinued.Systems
             }
 
             string baseName = GetStreetBaseName(streetName);
-            if (nameCount.GetValueOrDefault(baseName, 0) > 1 && !string.IsNullOrEmpty(crossStreet))
+            if (GetDictionaryValueOrDefault(nameCount, baseName) > 1 && !string.IsNullOrEmpty(crossStreet))
             {
                 string crossBase = GetStreetBaseName(crossStreet);
                 return $"{baseName}/\n{crossBase}";
             }
             return AbbreviateSuffix(streetName);
+        }
+
+        private static int GetDictionaryValueOrDefault(Dictionary<string, int> dictionary, string key)
+        {
+            return dictionary.TryGetValue(key, out int value) ? value : 0;
         }
 
         private (string streetName, string crossStreet) GetStopStreetAndCrossStreet(Entity stopEntity)

--- a/Systems/FirstPersonCameraPIPSystem.cs
+++ b/Systems/FirstPersonCameraPIPSystem.cs
@@ -103,7 +103,7 @@ namespace FirstPersonCameraContinued
                 var positon = CameraController.transform.position;
                 var rotation = CameraController.GetViewRotation();
 
-                Entity currentEntity = CameraController.GetFollowEntity();
+                Entity currentEntity = CameraController.GetAttachmentTarget();
                 if (currentEntity != _lastPipEntity)
                 {
                     _lastPipEntity = currentEntity;

--- a/Tests/FollowTargetStateTests.cs
+++ b/Tests/FollowTargetStateTests.cs
@@ -1,0 +1,32 @@
+using FirstPersonCameraContinued.DataModels;
+using Xunit;
+
+namespace FirstPersonCameraContinued.Tests;
+
+public class FollowTargetStateTests
+{
+    [Fact]
+    public void ResolvingAttachmentTargetDoesNotChangeSelectedSubject()
+    {
+        var state = new FollowTargetState<int>(0);
+
+        state.SelectSubject(42);
+        state.ResolveAttachmentTarget(9001);
+
+        Assert.Equal(42, state.SelectedSubject);
+        Assert.Equal(9001, state.AttachmentTarget);
+    }
+
+    [Fact]
+    public void ClearingSubjectAlsoClearsAttachmentTarget()
+    {
+        var state = new FollowTargetState<int>(0);
+
+        state.SelectSubject(42);
+        state.ResolveAttachmentTarget(9001);
+        state.SelectSubject(0);
+
+        Assert.Equal(0, state.SelectedSubject);
+        Assert.Equal(0, state.AttachmentTarget);
+    }
+}

--- a/Tests/FollowTargetStateTests.csproj
+++ b/Tests/FollowTargetStateTests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\DataModels\FollowTargetState.cs" Link="FollowTargetState.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
When a followed citizen boards a vehicle, follow mode could accidentally start treating the vehicle as the thing being followed. This keeps the person as the real target while still letting the camera ride along with the vehicle until they get out.

## Summary
- Keep the selected citizen as the logical follow target while resolving a separate camera attachment target for entered vehicles.
- Preserve follow state when a followed citizen boards and leaves a vehicle instead of switching permanently to the vehicle.
- Add focused tests for follow-target state transitions.

## Validation
- `dotnet test Tests/FollowTargetStateTests.csproj --no-restore` (2 passed)
- `dotnet build FirstPersonCameraContinued.csproj /p:ModPublisherCommand=Update /m:1 /nodeReuse:false /p:UseSharedCompilation=false` (0 errors; existing nullable warnings remain)
- Local gameplay retesting followed a citizen through subway boarding and disembarking without losing the citizen follow target.

## Notes
This is the base PR for a small stacked follow-up: mayor-modder/FirstPersonCameraContinued#4.